### PR TITLE
Use HTML reports instead of txt reports for MultiQC

### DIFF
--- a/long-read-variant-calling.wdl
+++ b/long-read-variant-calling.wdl
@@ -180,8 +180,8 @@ workflow LongReadVariantCalling {
             reports = flatten([
                 flatten(sequaliTask.json), 
                 flatten(select_all(deepVariantReports)),
-                select_all(clair3Vep.statsTxt),
-                select_all(deepVariantVep.statsTxt),
+                select_all(clair3Vep.statsHtml),
+                select_all(deepVariantVep.statsHtml),
             ]),
             dataDir = false,
     }


### PR DESCRIPTION
### Checklist
- [ ] Pull request details were added to CHANGELOG.md.
- [ ] Documentation was updated (if required).
- [ ] Workflow `parameter_meta` was added/updated (if required).
- [ ] Submodule branches are on develop or a tagged commit.

This fixes a bug with MultiQCs VEP txt parser by simply using the HTML parser instead.